### PR TITLE
Functionality for creating Consul backup

### DIFF
--- a/adsws/consul/__init__.py
+++ b/adsws/consul/__init__.py
@@ -1,0 +1,8 @@
+"""
+Consul application for the ADS (adsws)
+Provides standard consul maintenance functionality.
+"""
+
+import app
+from app import create_app
+import config

--- a/adsws/consul/manage.py
+++ b/adsws/consul/manage.py
@@ -1,0 +1,45 @@
+"""
+Management commands for consul related activities
+"""
+
+import time
+import json
+import consulate
+import boto
+from adsws.consul import create_app
+
+from flask.ext.script import Manager
+
+consul_manager = Manager(create_app())
+consul_manager.__doc__ = __doc__  # Overwrite default docstring
+
+@consul_manager.command
+def backup_consul(app_override=None):
+    """
+    """
+
+    app = consul_manager.app if app_override is None else app_override
+ 
+    consul = consulate.Consul(host=os.environ.get['CONSUL_HOST'])
+    # Open backup file
+    backup_file = "adsabs_consul_kv.%s.json" % time.strftime('%m%d%Y')
+    handle = open(backup_file, 'w')
+    # Get record for backup
+    records = consul.kv.records()
+    try:
+        handle.write(json.dumps(records) + '\n')
+        app.logger.info("Consul key/value store backup in: %s" % backup_file)
+    except exceptions.ConnectionError:
+        app.logger.error("Unable to create Consul backup file: %s" % backup_file)
+    # Finally, move backup over to S3
+    backup_dest = app.config.get('CONSUL_S3_BACKUP_BUCKET')
+    # Connect to S3
+    conn = boto.connect_s3()
+    k = Key(backup_dest)
+    k.key = backup_file
+    k.set_contents_from_filename(backup_file)
+    # Remove the local copy of the backup file
+    os.remove(backup_file)
+    
+    
+

--- a/manage.py
+++ b/manage.py
@@ -10,10 +10,12 @@ import os
 import flask
 from flask.ext.script import Manager
 from adsws.accounts.manage import accounts_manager
+from adsws.consul.manage import consul_manager
 
 manager = Manager(flask.Flask('manager'))
 
 manager.add_command("accounts", accounts_manager)
+manager.add_command("consul", consul_manager)
 
 @manager.command
 def generate_secret_key():


### PR DESCRIPTION
Backups of the Consul key/value store can be support through

  python /app/adsws/manage.py consul backup_consul

as a cronjob, installed into the adsws container (via mission control). 