### PR TITLE
Hotfix/issue#81/bootstrap optimise

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
      vb.cpus = 2
   end
 
-  config.vm.provider :docker do |docker|
+  config.vm.provision :docker do |docker|
     docker.pull_images "redis"
     docker.run "redis",
       args: "-d -p 6379:6379"

--- a/adsws/accounts/utils.py
+++ b/adsws/accounts/utils.py
@@ -5,18 +5,27 @@ from functools import wraps
 from flask import current_app, session
 from flask.ext.mail import Message
 from flask.ext.login import current_user as cu
-from flask.ext.login import logout_user
+from flask.ext.login import logout_user as flask_logout_user
 
 from .exceptions import ValidationError
 from .emails import Email
 
 
-def logout():
+def logout_user():
+    """
+    Logs out the user from a Flask session, and does some extra functionality on top of it, that is not
+    done normally by Flask-login
+
+    :return: message from Flask-login logout_user
+    """
 
     expunge_list = ['oauth_client']
 
-    logout_user()
-    [session.pop(item) for item in expunge_list]
+    message = flask_logout_user()
+    [session.pop(item, None) for item in expunge_list]
+
+    return message
+
 
 def get_post_data(request):
     """
@@ -112,7 +121,7 @@ def validate_password(password):
 
 
 def login_required(func):
-    '''
+    """
     If you decorate a view with this, it will ensure that the current user is
     logged in and authenticated before calling the actual view. (If they are
     not, it calls the :attr:`LoginManager.unauthorized` callback.) For
@@ -136,7 +145,7 @@ def login_required(func):
 
     :param func: The view function to decorate.
     :type func: function
-    '''
+    """
 
     @wraps(func)
     def decorated_view(*args, **kwargs):

--- a/adsws/accounts/utils.py
+++ b/adsws/accounts/utils.py
@@ -2,13 +2,21 @@ import datetime
 import requests
 from functools import wraps
 
-from flask import current_app
+from flask import current_app, session
 from flask.ext.mail import Message
 from flask.ext.login import current_user as cu
+from flask.ext.login import logout_user
 
 from .exceptions import ValidationError
 from .emails import Email
 
+
+def logout():
+
+    expunge_list = ['oauth_client']
+
+    logout_user()
+    [session.pop(item) for item in expunge_list]
 
 def get_post_data(request):
     """

--- a/adsws/accounts/views.py
+++ b/adsws/accounts/views.py
@@ -398,7 +398,7 @@ class UserAuthView(Resource):
             return {"error": "account has not been verified"}, 403
 
         # Logout of previous user (may have been bumblebee)
-        if current_user.is_authenticated():
+        if current_user.is_authenticated:
             logout_user()
         login_user(u)  # Login to real user
         user_manipulator.update(
@@ -545,7 +545,7 @@ class Bootstrap(Resource):
 
         # If we visit this endpoint and are unauthenticated, then login as
         # our anonymous user
-        if not current_user.is_authenticated():
+        if not current_user.is_authenticated:
             login_user(user_manipulator.first(
                 email=current_app.config['BOOTSTRAP_USER_EMAIL']
             ))
@@ -555,7 +555,7 @@ class Bootstrap(Resource):
                 client, token = Bootstrap.load_client(
                     session.get('oauth_client', '')
                 )
-                if client.user_id != current_user.get_id():
+                if client.user_id != int(current_user.get_id()):
                     raise NoClientError("client/user mistmatch")
             except (NoTokenError, NoClientError):
                 client, token = Bootstrap.bootstrap_bumblebee()

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,3 @@ six
 redis
 ConcurrentLogHandler
 flask-consulate
-.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Flask>=0.9
 gunicorn
 psycopg2
 Flask-SQLAlchemy
+Flask-login==0.2.11
 Flask-Security
 Flask-Menu
 Flask-Script


### PR DESCRIPTION
This addresses and should close issue #81.

Bootstrap code now correctly comparsed int against int inside if statement.

Tests added for this.

Bootstrap doesn't access database unless the session actually has an Oauth token.

Tests for this added.

Logout user is overriden to ensure that content no longer needed is cleaned, such as oauth_client.

Flask-Login fixed until Flask-Security is modified to work with the latest release.