### PR TITLE
Hotfix modify the input that is required on the feedback end point

### DIFF
--- a/adsws/feedback/views.py
+++ b/adsws/feedback/views.py
@@ -44,34 +44,24 @@ class SlackFeedback(Resource):
         channel = post_data.get('channel', '#feedback')
         username = post_data.get('username', 'TownCrier')
 
+        name = post_data.get('name', 'TownCrier')
+        reply_to = post_data.get('_replyto', 'TownCrier@lonelyvilla.ge')
+
         try:
-            name = post_data['name']
-            reply_to = post_data['_replyto']
             comments = post_data['comments']
-            subject = post_data['_subject']
-            feedback_type = post_data['feedback-type']
         except BadRequestKeyError:
             raise
 
-        if feedback_type == 'bug':
-            icon_emoji = ':goberserk:'
-        elif feedback_type == 'comment':
-            icon_emoji = ':neckbeard:'
-        else:
-            icon_emoji = ':see_no_evil:'
+        icon_emoji = ':goberserk:'
 
         prettified_data = {
             'text': '```Incoming Feedback```\n'
                     '*Commenter*: {commenter}\n'
                     '*e-mail*: {email}\n'
-                    '*Type*: {feedback_type}\n'
-                    '*Subject*: {subject}\n'
                     '*Feedback*: {feedback}'.format(
                         commenter=name,
                         email=reply_to,
-                        feedback_type=feedback_type,
-                        feedback=comments,
-                        subject=subject
+                        feedback=comments
                     ),
             'username': username,
             'channel': channel,

--- a/adsws/tests/test_feedback.py
+++ b/adsws/tests/test_feedback.py
@@ -151,14 +151,12 @@ class TestFunctionals(TestBase):
         end point
         """
         # User fills the user feedback form
-        form_data = dict(
-            name='Commmenter',
-            comments='Why are my citations missing?',
-        )
-        form_data['_subject'] = 'Bumblebee Feedback'
-        form_data['feedback-type'] = 'bug'
-        form_data['_replyto'] = 'commenter@email.com'
-        form_data['g-recaptcha-response'] = 'correct_response'
+        form_data = {
+            'name': 'Commenter',
+            'comments': 'Why are my citations missing?',
+            '_replyto': 'commenter@email.com',
+            'g-recaptcha-response': 'correct_response'
+        }
 
         # User presses submit on the feedback form
         url = url_for('slackfeedback')
@@ -169,13 +167,36 @@ class TestFunctionals(TestBase):
             )
         self.assertEqual(response.status_code, 200)
 
-    def test_400_if_not_right_data(self):
+    def test_submitting_feedback_with_minimal_information(self):
         """
-        Checks the passed data, at the moment we accept specific fields
+        Check they can send minimal information to the end point
         """
         # User fills the user feedback form
-        form_data = dict(random='random')
-        form_data['g-recaptcha-response'] = 'correct_response'
+        form_data = {
+            'comments': 'Why are my citations missing?',
+            'g-recaptcha-response': 'correct_response'
+        }
+
+        # User presses submit on the feedback form
+        url = url_for('slackfeedback')
+        with SlackWebService() as SLW, GoogleRecaptchaService() as GRS:
+            response = self.client.post(
+                url,
+                data=form_data
+            )
+        self.assertEqual(response.status_code, 200)
+
+    def test_404_if_not_right_data(self):
+        """
+        Checks the passed data, at the moment we accept specific fields, and so it will not work if the user does not
+        supply any comments
+        """
+        # User fills the user feedback form
+        form_data = {
+            'name': 'Commenter',
+            '_replyto': 'commenter@email.com',
+            'g-recaptcha-response': 'correct_response'
+        }
 
         # User presses submit on the feedback form
         url = url_for('slackfeedback')
@@ -235,8 +256,6 @@ class TestUnits(TestBase):
             'text': '```Incoming Feedback```\n'
                     '*Commenter*: Commenter\n'
                     '*e-mail*: commenter@email.com\n'
-                    '*Type*: bug\n'
-                    '*Subject*: Bumblebee Feedback\n'
                     '*Feedback*: Why are my citations missing?',
             'username': 'TownCrier',
             'channel': '#feedback',
@@ -246,7 +265,6 @@ class TestUnits(TestBase):
         form_data = {
             'name': 'Commenter',
             'comments': 'Why are my citations missing?',
-            'feedback-type': 'bug',
             '_subject': 'Bumblebee Feedback',
             '_replyto': 'commenter@email.com'
         }


### PR DESCRIPTION
Updated the slack end point such that:
  1. You only need send 'comments' to the end point
  2. You can optionally send 'email' and 'name'
  3. Removed 'feedback_type', no longer passed in message

Updated tests.