### PR TITLE
Hotfix/issue#85/verification time limit

### DIFF
--- a/adsws/accounts/manage.py
+++ b/adsws/accounts/manage.py
@@ -59,6 +59,7 @@ def cleanup_users(app_override=None, timedelta="hours=24"):
         for user in users:
             db.session.delete(user)
             deletions += 1
+            app.logger.info("Deleted unverified user: {}".format(user.email))
         try:
             db.session.commit()
         except Exception, e:

--- a/adsws/accounts/manage.py
+++ b/adsws/accounts/manage.py
@@ -29,7 +29,7 @@ def parse_timedelta(s):
     return datetime.timedelta(**td)
 
 @accounts_manager.command
-def cleanup_users(app_override=None, timedelta="hours=2"):
+def cleanup_users(app_override=None, timedelta="hours=24"):
     """
     Deletes stale users from the database. Stale users are defined as users
     that have a registered_at value of `now`-`timedelta` but not confirmed_at

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Flask-Breadcrumbs==0.3.0
 oauthlib==0.7.2
 git+https://github.com/lepture/flask-oauthlib.git@e092a5f46ff6c78d313a6eb2f89ee746fb190dfb#egg=Flask-OAuthlib
 Flask-WTF==0.11
+WTForms-Components==0.9.9
 WTForms-Alchemy==0.13.3
 Flask-Registry==0.2.0
 Flask-Email==1.4.4


### PR DESCRIPTION
Closes issue #85.

Time limit increased to 24hrs.

Logs updated to include the unverified user being deleted for easier troubleshooting, not just the number of.