### PR TITLE
Issue #93: Feedback end point receive any key/values

### DIFF
--- a/adsws/feedback/views.py
+++ b/adsws/feedback/views.py
@@ -54,15 +54,23 @@ class SlackFeedback(Resource):
 
         icon_emoji = ':goberserk:'
 
+        text = [
+            '```Incoming Feedback```',
+            '*Commenter*: {}'.format(name),
+            '*e-mail*: {}'.format(reply_to),
+            '*Feedback*: {}'.format(comments)
+        ]
+
+        used = ['channel', 'username', 'name', '_replyto', 'comments']
+        for key in post_data:
+            if key in used:
+                continue
+            text.append('*{}*: {}'.format(key, post_data[key]))
+
+        text = '\n'.join(text)
+
         prettified_data = {
-            'text': '```Incoming Feedback```\n'
-                    '*Commenter*: {commenter}\n'
-                    '*e-mail*: {email}\n'
-                    '*Feedback*: {feedback}'.format(
-                        commenter=name,
-                        email=reply_to,
-                        feedback=comments
-                    ),
+            'text': text,
             'username': username,
             'channel': channel,
             'icon_emoji': icon_emoji

--- a/adsws/tests/test_feedback.py
+++ b/adsws/tests/test_feedback.py
@@ -265,7 +265,37 @@ class TestUnits(TestBase):
         form_data = {
             'name': 'Commenter',
             'comments': 'Why are my citations missing?',
-            '_subject': 'Bumblebee Feedback',
+            '_replyto': 'commenter@email.com'
+        }
+
+        prettified_post_data = SlackFeedback().prettify_post(form_data)
+
+        for key in post_data_sent.keys():
+            self.assertEqual(post_data_sent[key], prettified_post_data[key])
+
+    def test_can_send_abritrary_keyword_values(self):
+        """
+        Test the end point is not restrictive on the keyword values it can
+        create content for.
+        """
+
+        post_data_sent = {
+            'text': '```Incoming Feedback```\n'
+                    '*Commenter*: Commenter\n'
+                    '*e-mail*: commenter@email.com\n'
+                    '*Feedback*: Why are my citations missing?\n'
+                    '*IP Address*: 127.0.0.1\n'
+                    '*Browser*: Firefox v42',
+            'username': 'TownCrier',
+            'channel': '#feedback',
+            'icon_emoji': ':goberserk:'
+        }
+
+        form_data = {
+            'name': 'Commenter',
+            'comments': 'Why are my citations missing?',
+            'Browser': 'Firefox v42',
+            'IP Address': '127.0.0.1',
             '_replyto': 'commenter@email.com'
         }
 


### PR DESCRIPTION
The end point has been updated to pretty-print any key word that is passed to it. It still requires at least a comment from the user, otherwise it will raise a 400 for a KeyErorr.