### PR TITLE
Slack feedback emoji configerable

### DIFF
--- a/adsws/feedback/config.py
+++ b/adsws/feedback/config.py
@@ -7,6 +7,7 @@ EXTENSIONS = [
 ]
 
 FEEDBACK_SLACK_END_POINT = 'https://hooks.slack.com/services/TOKEN/TOKEN'
+FEEDBACK_SLACK_EMOJI = ':question:'
 GOOGLE_RECAPTCHA_ENDPOINT = 'https://www.google.com/recaptcha/api/siteverify'
 GOOGLE_RECAPTCHA_PRIVATE_KEY = 'MY_PRIVATE_KEY'
 CORS_DOMAINS = ['https://ui.adsabs.harvard.edu']

--- a/adsws/feedback/views.py
+++ b/adsws/feedback/views.py
@@ -52,7 +52,7 @@ class SlackFeedback(Resource):
         except BadRequestKeyError:
             raise
 
-        icon_emoji = ':goberserk:'
+        icon_emoji = current_app.config['FEEDBACK_SLACK_EMOJI']
 
         text = [
             '```Incoming Feedback```',

--- a/adsws/tests/test_feedback.py
+++ b/adsws/tests/test_feedback.py
@@ -279,7 +279,7 @@ class TestUnits(TestBase):
         Test the end point is not restrictive on the keyword values it can
         create content for.
         """
-
+        emoji = current_app.config['FEEDBACK_SLACK_EMOJI']
         post_data_sent = {
             'text': '```Incoming Feedback```\n'
                     '*Commenter*: Commenter\n'
@@ -289,7 +289,7 @@ class TestUnits(TestBase):
                     '*Browser*: Firefox v42',
             'username': 'TownCrier',
             'channel': '#feedback',
-            'icon_emoji': ':goberserk:'
+            'icon_emoji': emoji
         }
 
         form_data = {

--- a/adsws/tests/test_feedback.py
+++ b/adsws/tests/test_feedback.py
@@ -252,6 +252,7 @@ class TestUnits(TestBase):
         """
         Tests that the input given is parsed sensibly for slack
         """
+        emoji = current_app.config['FEEDBACK_SLACK_EMOJI']
         post_data_sent = {
             'text': '```Incoming Feedback```\n'
                     '*Commenter*: Commenter\n'
@@ -259,7 +260,7 @@ class TestUnits(TestBase):
                     '*Feedback*: Why are my citations missing?',
             'username': 'TownCrier',
             'channel': '#feedback',
-            'icon_emoji': ':goberserk:'
+            'icon_emoji': emoji
         }
 
         form_data = {


### PR DESCRIPTION
Small update to make Slack feedback emoji configurable (so we can easily override it with local_config).