### PR TITLE
Upgrade ratelimit extension to correctly report limits in HTTP headers

### DIFF
--- a/adsws/api/discoverer/views.py
+++ b/adsws/api/discoverer/views.py
@@ -61,6 +61,12 @@ class ProxyView(Resource):
             ep = path
         resp = self.__getattribute__(request.method.lower())(ep, request)
 
+        if isinstance(resp, tuple):
+            if len(resp) == 2:
+                text = resp[0]
+                status_code = resp[1]
+                return text, status_code
+
         headers = {}
         if resp.headers:
             [headers.update({key: resp.headers[key]}) for key in current_app.config['REMOTE_PROXY_ALLOWED_HEADERS'] if key in resp.headers]

--- a/config.py
+++ b/config.py
@@ -10,3 +10,7 @@ TESTING = False
 # db will be saved at adsws/api/adsws.sqlite
 SQLALCHEMY_DATABASE_URI = 'sqlite://'
 SITE_SECURE_URL = 'http://0.0.0.0:5000'
+
+# Flask session config (http://flask.pocoo.org/docs/0.12/config/)
+PERMANENT_SESSION_LIFETIME = 3600*24*365.25 # 1 year in seconds
+SESSION_REFRESH_EACH_REQUEST = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/adsabs/ADSMicroserviceUtils.git@v1.0.2
 flask-headers==1.0
-git+https://github.com/adsabs/flask-limiter.git@968a0faaa6fce47bf3fb7928ca2b10a00917d6eb#egg=flask-limiter
+git+https://github.com/adsabs/flask-limiter.git@fb1bbd3e4894c4298798601121dbf9782a6bafe8#egg=flask-limiter
 flask-cors==1.9.0
 flask-RESTful==0.3.4
 flask-sslify==0.1.5


### PR DESCRIPTION
- Also added an extra control to return good codes from microservices
when they fail