### PR TITLE
Added extra info to /accounts/token endpoint

### DIFF
--- a/adsws/accounts/views.py
+++ b/adsws/accounts/views.py
@@ -238,7 +238,10 @@ class PersonalTokenView(Resource):
             )
             return {'message': 'no ADS API token found'}, 500
 
-        return print_token(token)
+        output = print_token(token)
+        output['client_id'] = client.client_id
+        output['user_id'] = current_user.get_id()
+        return output
 
     def put(self):
         """
@@ -305,7 +308,11 @@ class PersonalTokenView(Resource):
             current_app.logger.info(
                 "Updated ADS API token for {0}".format(current_user.email)
             )
-        return print_token(token)
+
+        output = print_token(token)
+        output['client_id'] = client.client_id
+        output['user_id'] = current_user.get_id()
+        return output
 
 
 class LogoutView(Resource):


### PR DESCRIPTION
Added client_id and user_id to the returned responses for accounts/token endpoint, which is needed by the gateway resolver service for logging purposes.