### PR TITLE
Fixes rate limit response headers and affinity

### DIFF
--- a/adsws/api/config.py
+++ b/adsws/api/config.py
@@ -39,6 +39,6 @@ WEBSERVICES = {
 # WEBSERVICES_DISCOVERY_CACHE_DIR='/tmp'
 
 API_PROXYVIEW_HEADERS = {'Cache-Control': 'public, max-age=600'}
-REMOTE_PROXY_ALLOWED_HEADERS = ['Content-Type', 'Content-Disposition']
+REMOTE_PROXY_ALLOWED_HEADERS = ['Content-Type', 'Content-Disposition', 'Set-Cookie'] # Set-Cookie required for affinity
 
 AFFINITY_ENHANCED_ENDPOINTS = {"/search": "sroute",} # keys: deploy paths, value: cookie

--- a/adsws/api/discoverer/affinity.py
+++ b/adsws/api/discoverer/affinity.py
@@ -100,7 +100,7 @@ def affinity_decorator(storage, name="sroute"):
                 response_headers = None
 
             if user_token and response_headers:
-                set_cookie = response_headers.get('Set-Cookie', None)
+                set_cookie = response_headers.pop('Set-Cookie', None)
                 if set_cookie:
                     # If solr issued a set cookie, store the value in redis linked to the user token
                     cookie = Cookie.SimpleCookie()


### PR DESCRIPTION
The problems fixed here did not happen before when solr-service was integrated as a local package in adsws. The problems were:

- Rate limit response headers stopped containing information about the remaining number of requests (as reported in https://github.com/adsabs/adsabs-dev-api/issues/72)
- Affinity stopped working for Solr